### PR TITLE
Cleaning up all user's sessions

### DIFF
--- a/endpoints/connection_management.ts
+++ b/endpoints/connection_management.ts
@@ -73,6 +73,12 @@ const installHandlers = (orchestrator: Orchestrator, user: User) => {
     return false;
   };
 
+  /**
+   * Gets all sessions that the given user is administrator of and forcibly
+   * closes them. This serves the purpose of cleaning up dangling sessions.
+   *
+   * @returns Number of sessions closed
+   */
   const cleanUpDanglingSessions = () => {
     const administratedSessions = orchestrator.getAdministratedSessions(user);
 

--- a/endpoints/connection_management.ts
+++ b/endpoints/connection_management.ts
@@ -59,7 +59,7 @@ const installHandlers = (orchestrator: Orchestrator, user: User) => {
    *
    * @returns True if the session was also deleted
    */
-  const cleanUpSession = () => {
+  const cleanUpActiveSession = () => {
     const { session } = user;
     session?.removeUser(user);
 
@@ -80,7 +80,7 @@ const installHandlers = (orchestrator: Orchestrator, user: User) => {
   socket.on(EndpointNames.LOGOUT, (data, callback) => {
     logger.debug(EndpointNames.LOGOUT, "Logged out user", user.name);
 
-    if (cleanUpSession()) {
+    if (cleanUpActiveSession()) {
       logger.debug(EndpointNames.LOGOUT, "User was admin, closing session");
     }
 
@@ -95,7 +95,7 @@ const installHandlers = (orchestrator: Orchestrator, user: User) => {
   socket.on("disconnect", () => {
     logger.debug("[DISCONNECT] Disconnected user", user.name);
 
-    if (cleanUpSession()) {
+    if (cleanUpActiveSession()) {
       logger.debug("[DISCONNECT] User was admin, closing session");
     }
 


### PR DESCRIPTION
Added additional function `cleanUpDanglingSessions()` which is called on logout and disconnect. The function gets all sessions administrated by the given user and forcibly closes them.

Closes #4