### PR TITLE
External transport error handling

### DIFF
--- a/endpoints/error_codes.ts
+++ b/endpoints/error_codes.ts
@@ -2,6 +2,7 @@ enum ErrorCodes {
   OK = 0,
   MISSING_CREDENTIALS = 204,
 
+  SESSION_ADD_FAILED = 404,
   SESSION_DELETE_UNAUTHORIZED = 501,
   SESSION_NOT_FOUND = 503,
   SESSION_NOT_EMPTY = 504,
@@ -29,6 +30,7 @@ export const ErrorMessages: { [key in ErrorCodes]: string } = {
   [ErrorCodes.OK]: "OK",
   [ErrorCodes.MISSING_CREDENTIALS]: "The user credentials are missing",
 
+  [ErrorCodes.SESSION_ADD_FAILED]: "Could not create session",
   [ErrorCodes.SESSION_NOT_FOUND]: "The session was not found",
   [ErrorCodes.SESSION_DELETE_UNAUTHORIZED]: "You are not the administrator of this session",
   [ErrorCodes.SESSION_NOT_EMPTY]: "The session is not empty",

--- a/endpoints/session_management.ts
+++ b/endpoints/session_management.ts
@@ -23,25 +23,34 @@ const installHandlers = (orchestrator: Orchestrator, user: User) => {
 
     logger.debug(EndpointNames.ADD_SESSION, "Creating new session with name", sessionName);
 
-    const session = new Session(
-      sessionName.trim(),
-      sessionDescription,
-      sessionProtocol,
-      new Scenario(scenarioId, scenarioName, scenarioDescription),
-      orchestrator.transportManager
-    );
+    try {
+      const session = new Session(
+        sessionName.trim(),
+        sessionDescription,
+        sessionProtocol,
+        new Scenario(scenarioId, scenarioName, scenarioDescription),
+        orchestrator.transportManager
+      );
 
-    logger.debug(EndpointNames.ADD_SESSION, "Adding user", user.name, "as admin to new session", session.name);
+      logger.debug(EndpointNames.ADD_SESSION, "Adding user", user.name, "as admin to new session", session.name);
 
-    session.addUser(user);
-    session.setAdministrator(user);
-    orchestrator.addSession(session);
+      session.addUser(user);
+      session.setAdministrator(user);
+      orchestrator.addSession(session);
 
-    callback(util.createCommandResponse(
-      data,
-      ErrorCodes.OK,
-      session.serialize()
-    ));
+      callback(util.createCommandResponse(
+        data,
+        ErrorCodes.OK,
+        session.serialize()
+      ));
+    } catch (err) {
+      logger.error(EndpointNames.ADD_SESSION, "Error during session creation:", err);
+
+      return callback(util.createCommandResponse(
+        data,
+        ErrorCodes.SESSION_ADD_FAILED
+      ));
+    }
   });
 
   /**

--- a/transport/manager/transport_manager.ts
+++ b/transport/manager/transport_manager.ts
@@ -53,59 +53,52 @@ class TransportManager {
    * @returns An instantiated transport, subclass of `ExternalTransport`, depending on `protocol` or DummyTransport on error
    */
   private assignExternalTransport(protocol: ExternalTransportType, session: Session): ExternalTransport | DummyTransport {
-    try {
-      // Load config for protocol type
-      const transportConfig: TransportConfig = loadConfigSync(`config/${protocol}-config.json`);
-      const { portMapping } = transportConfig;
+    // Load config for protocol type
+    const transportConfig: TransportConfig = loadConfigSync(`config/${protocol}-config.json`);
+    const { portMapping } = transportConfig;
 
-      // Get all ports delcared in the port mapping
-      const declaredPorts = portMapping.map((p) => p.port );
-      // Get ports of running transports
-      const runningPorts = this.#externalTransports.get(protocol)?.map((t) => t.getPort()) || [];
+    // Get all ports delcared in the port mapping
+    const declaredPorts = portMapping.map((p) => p.port );
+    // Get ports of running transports
+    const runningPorts = this.#externalTransports.get(protocol)?.map((t) => t.getPort()) || [];
 
-      // Get first port which has been declared but not instantiated yet
-      const availablePort = declaredPorts.find((p) => !runningPorts.includes(p));
+    // Get first port which has been declared but not instantiated yet
+    const availablePort = declaredPorts.find((p) => !runningPorts.includes(p));
 
-      // If we found a declared but not instantiated port
-      if (availablePort) {
-        logger.debug("Found unassigned port", availablePort, "for starting", protocol, "transport for session", session.name);
+    // If we found a declared but not instantiated port
+    if (availablePort) {
+      logger.debug("Found unassigned port", availablePort, "for starting", protocol, "transport for session", session.name);
 
-        // Instantiate new transport and start it
-        const transport = ExternalTransportBuilder.instantiate(protocol, EXTERNAL_HOSTNAME, availablePort, transportConfig, session);
-        transport.start();
+      // Instantiate new transport and start it
+      const transport = ExternalTransportBuilder.instantiate(protocol, EXTERNAL_HOSTNAME, availablePort, transportConfig, session);
+      transport.start();
 
-        // Add to map of running transports
-        if (this.#externalTransports.has(protocol)) {
-          this.#externalTransports.get(protocol)?.push(transport);
-        } else {
-          this.#externalTransports.set(protocol, [transport]);
-        }
-
-        return transport;
+      // Add to map of running transports
+      if (this.#externalTransports.has(protocol)) {
+        this.#externalTransports.get(protocol)?.push(transport);
+      } else {
+        this.#externalTransports.set(protocol, [transport]);
       }
 
-      // Otherwise, return existing transport with least sessions
-      const leastOccupiedTransport = this.#externalTransports.get(protocol)?.sort((a, b) => {
-        if (a.countSessions() < b.countSessions()) {
-          return -1;
-        } else if (b.countSessions() > b.countSessions()) {
-          return 1;
-        }
-
-        return 0;
-      })[0]!;
-
-      logger.debug("Assigning session", session.name, "to", protocol, "transport with", leastOccupiedTransport?.countSessions(), "sessions");
-
-      // Add session to transport
-      leastOccupiedTransport.addSession(session);
-      return leastOccupiedTransport;
-    } catch {
-      logger.warn("No config for protocol type", protocol, "found! Using Socket.IO transport as fallback");
-
-      // Return DummyTransport in case of error
-      return new DummyTransport();
+      return transport;
     }
+
+    // Otherwise, return existing transport with least sessions
+    const leastOccupiedTransport = this.#externalTransports.get(protocol)?.sort((a, b) => {
+      if (a.countSessions() < b.countSessions()) {
+        return -1;
+      } else if (b.countSessions() > b.countSessions()) {
+        return 1;
+      }
+
+      return 0;
+    })[0]!;
+
+    logger.debug("Assigning session", session.name, "to", protocol, "transport with", leastOccupiedTransport?.countSessions(), "sessions");
+
+    // Add session to transport
+    leastOccupiedTransport.addSession(session);
+    return leastOccupiedTransport;
   }
 }
 


### PR DESCRIPTION
Removed try-catch block from `assignExternalTransport()` so all exception during session creation bubble up to `ADD_SESSION` where they are caught.

If any exception during session creation occurs, the error is logged to the command line and a generic error is returned to the client.

Closes #13 