### PR TITLE
Added method for cleaning up transports

### DIFF
--- a/app/orchestrator.ts
+++ b/app/orchestrator.ts
@@ -83,13 +83,15 @@ class Orchestrator implements Serializable {
   }
 
   /**
-   * Removes a given session from the orchestrator.
+   * Removes a given session from the orchestrator and clean up any external
+   * transports which have no more sessions.
    *
    * @param session Session to remove
    */
   public removeSession(session: Session) {
     session.closeSession();
     this.#sessions = this.#sessions.filter((s) => s.id != session.id);
+    this.#transportManager.cleanupTransports();
   }
 
 

--- a/transport/external_transport.ts
+++ b/transport/external_transport.ts
@@ -7,7 +7,7 @@ import User from "../app/user";
 import Session from "../app/session";
 
 abstract class ExternalTransport implements Transport {
-  protected id = uuidv4();
+  public id = uuidv4();
   protected process?: childProcess.ChildProcessWithoutNullStreams;
 
   protected abstract type: string;

--- a/transport/manager/transport_manager.ts
+++ b/transport/manager/transport_manager.ts
@@ -100,6 +100,24 @@ class TransportManager {
     leastOccupiedTransport.addSession(session);
     return leastOccupiedTransport;
   }
+
+  /**
+   * Stop all external transports that have no more sessions assigned to them.
+   */
+  public cleanupTransports() {
+    this.#externalTransports.forEach((transports, protocol) => {
+      this.#externalTransports.set(protocol, transports.reduce<Array<ExternalTransport>>((acc, transport) => {
+        if (transport.countSessions() == 0) {
+          logger.debug("Cleaning up transport", transport.id, "for protocol", protocol);
+          transport.destroy();
+
+          return acc;
+        }
+
+        return acc.concat(transport);
+      }, []));
+    });
+  }
 }
 
 export default TransportManager;


### PR DESCRIPTION
Added method `TransportManager.cleanupTransports()` which calls `destroy()` on all transports which have no more sessions assigned to them.

This method is called by `Orchestrator.removeSession()`, i.e. every time a session is closed.

Closes #16