### PR TITLE
Configuration is mounted from the host machine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 **/.git
 **/node_modules
 **/.yarn/cache
+.env

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 **/node_modules
 **/.yarn/cache
 .env
+**/config

--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,4 @@ REVISION
 
 *.swp
 config/*.json
-config/packages/
+packages/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:21-alpine3.17
 
 ADD . /code/
-ADD config/package[s] /packages
+ADD ./package[s] /packages
 
 WORKDIR /code
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ bit outdated, therefore, we recommend you download Docker from Docker's APT
 repositories. Follow [this guide](https://docs.docker.com/engine/install/ubuntu/)
 to do so.
 
+### External SFUs
+
+External SFU binaries placed inside a folder `packages/` in the project root
+are placed inside to container during build time inside the folder `/packages`.
+Keep this in mind when writing SFU config files.
+
 ## Development
 
 ### Building

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     environment:
       - PORT=8090
       - LOG_LEVEL=debug
+    volumes:
+      - ./config/:/code/config
+      - ./.env:/code/.env
     ports:
       - "8090:8090"
       - "8094:8094"

--- a/logger.ts
+++ b/logger.ts
@@ -4,7 +4,8 @@ import socketIOTransport from "winston-socket.io";
 import { getFromEnvironment } from "./util";
 import EndpointNames from "./endpoints/endpoint_names";
 
-const [ LOG_LEVEL, PORT ] = getFromEnvironment(["LOG_LEVEL", "PORT"]);
+const [ PORT ] = getFromEnvironment(["LOG_LEVEL", "PORT"]);
+const [ LOG_LEVEL ] = getFromEnvironment(["LOG_LEVEL"], "debug");
 const [ LOG_FILE, LOG_SERVER ] = getFromEnvironment(["LOG_FILE", "LOG_SERVER"], null);
 
 /**


### PR DESCRIPTION
The directory `config/` and the config file `.env` are now mounted as volumes from the host machine instead of being placed inside the container during build time.

Also, the location for external SFU binaries has changed from `./config/packages/` to `./packages/`

Closes #22