### PR TITLE
Move from Alpine to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,10 @@ ADD ./package[s] /packages
 WORKDIR /code
 
 # Add evanescent directory to library search path
-RUN echo "/packages/evanescent" > /etc/ld.so.conf.d/evanescent.conf
-RUN ldconfig
+RUN echo "/packages/evanescent" > /etc/ld.so.conf.d/evanescent.conf && ldconfig
 
 # Install Python for TCP reflector
-RUN apt update
-RUN apt install -y python3
+RUN apt update && apt install -y python3
 
 RUN yarn install && \
     yarn build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM node:22-alpine3.18
+FROM node:22
 
 ADD . /code/
 ADD ./package[s] /packages
 
 WORKDIR /code
 
-# These packages are needed to run evanescent and the webrtc sfu
-RUN apk add gcompat
-# Add evanescent directory to search path
-RUN echo "/lib:/usr/local/lib:/usr/lib:/packages/evanescent" > /etc/ld-musl-x86_64.path
 # Install Python for TCP reflector
-RUN apk add --update --no-cache python3
+RUN apt update
+RUN apt install -y python3
 
 RUN yarn install && \
     yarn build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /code
 
 # Add evanescent directory to library search path
 RUN echo "/packages/evanescent" > /etc/ld.so.conf.d/evanescent.conf
+RUN ldconfig
 
 # Install Python for TCP reflector
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22
+FROM node:22-bookworm-slim
 
 ADD . /code/
 ADD ./package[s] /packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ADD ./package[s] /packages
 
 WORKDIR /code
 
+# Add evanescent directory to library search path
+RUN echo "/packages/evanescent" > /etc/ld.so.conf.d/evanescent.conf
+
 # Install Python for TCP reflector
 RUN apt update
 RUN apt install -y python3


### PR DESCRIPTION
This pull request changes the base image of the docker image from Alpine 3.18 to Debian Bookworm slim. It also adds the `evanescent` directory to the library search path and reloads it using `ldconfig`.

We're using Debian since the official Node Docker image is based on Debian instead of Ubuntu and it avoids us having to build the entire image from scratch.

Moving to Debian increases the image size from ~330MB to ~430MB.

Closes #38